### PR TITLE
chore(dev-tools): add Claude Code project documentation and ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,12 @@ web-ext.config.ts
 *.njsproj
 *.sln
 *.sw?
+
+# Ignore Claude Code Local Settings
+# https://docs.anthropic.com/en/docs/claude-code/settings#settings-files
+.claude/settings.local.json
+
+# Ignore Serena ouput files except project.yml
+# @see https://github.com/oraios/serena
+.serena/*
+!.serena/project.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,67 @@
+# language of the project (csharp, python, rust, java, typescript, go, cpp, or ruby)
+#  * For C, use cpp
+#  * For JavaScript, use typescript
+# Special requirements:
+#  * csharp: Requires the presence of a .sln file in the project folder.
+language: typescript
+
+# whether to use the project's gitignore file to ignore files
+# Added on 2025-04-07
+ignore_all_files_in_gitignore: true
+# list of additional paths to ignore
+# same syntax as gitignore, so you can use * and **
+# Was previously called `ignored_dirs`, please update your config if you are using that.
+# Added (renamed)on 2025-04-07
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions,
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project by name.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_lines`: Deletes a range of lines within a file.
+#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
+#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
+#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file or directory.
+#  * `initial_instructions`: Gets the initial instructions for the current project.
+#     Should only be used in settings where the system prompt cannot be set,
+#     e.g. in clients you have no control over, like Claude Desktop.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_at_line`: Inserts content at a given line in a file.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: Lists memories in Serena's project-specific memory store.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
+#  * `remove_project`: Removes a project from the Serena configuration.
+#  * `replace_lines`: Replaces a range of lines within a file with new content.
+#  * `replace_symbol_body`: Replaces the full definition of a symbol.
+#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
+#  * `switch_modes`: Activates modes by providing a list of their names
+#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
+#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
+#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
+#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+excluded_tools: []
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+project_name: "browser-extension"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+WXT + React browser extension using TypeScript. This is a cross-browser extension that supports both Chrome and Firefox.
+
+## Development Commands
+
+### Essential Commands
+
+```bash
+# Development
+pnpm dev           # Chrome development with hot reload
+pnpm dev:firefox   # Firefox development
+
+# Code Quality (ALWAYS run before committing)
+pnpm lint          # Run all linters
+pnpm fix           # Auto-fix issues
+
+# Building
+pnpm build         # Production build (Chrome)
+pnpm build:firefox # Production build (Firefox)
+```
+
+### Testing Changes
+
+1. Run `pnpm lint` to check for issues
+2. Run `pnpm fix` to auto-fix
+3. Test in browser with `pnpm dev`
+4. Verify production build with `pnpm build`
+
+## Architecture
+
+### Extension Entry Points
+
+- **`entrypoints/background.ts`**: Background service worker using `defineBackground()`
+- **`entrypoints/content.ts`**: Content scripts with match patterns using `defineContentScript()`
+- **`entrypoints/popup/`**: React popup UI
+  - `App.tsx`: Main React component
+  - `main.tsx`: React entry point
+
+### Key Patterns
+
+- WXT's `define*` functions for extension APIs
+- React 19 with automatic JSX transform (no React import needed)
+- TypeScript with `.ts` extension imports allowed
+- ESLint + Prettier for code quality
+
+## Development Workflow
+
+### Before Making Changes
+
+1. Understand WXT's API structure (defineBackground, defineContentScript, etc.)
+2. Follow existing React component patterns in popup/
+3. Use browser.\* APIs for WebExtensions
+
+### After Making Changes
+
+1. **ALWAYS run**: `pnpm lint` and fix any issues
+2. **If errors**: Run `pnpm fix` for auto-fixing
+3. **Test locally**: `pnpm dev` to verify changes work
+4. **Commit format**: `type(scope): description` (conventional commits enforced)
+
+## Important Notes
+
+- Husky runs lint-staged on pre-commit (Prettier → ESLint → TypeScript check)
+- No GitHub @ mentions in commits (custom rule)
+- Build outputs: `.output/chrome-mv3/` and `.output/firefox-mv*/`
+- WXT handles manifest.json generation automatically


### PR DESCRIPTION
## Summary
- Add CLAUDE.md with project-specific guidance for Claude Code development
- Configure .gitignore to properly exclude Claude Code and Serena tool files
- Set up Serena project configuration for enhanced code analysis

## Changes
### Documentation
- **CLAUDE.md**: Comprehensive project documentation including:
  - Project overview (WXT + React browser extension)
  - Essential development commands
  - Architecture patterns and entry points
  - Development workflow guidelines
  - Code quality standards

### Configuration
- **.gitignore**: Added exclusions for:
  - Claude Code local settings (`.claude/settings.local.json`)
  - Serena tool outputs (while preserving `project.yml`)
  
- **.serena/project.yml**: Project configuration for Serena code analysis tools

## Test Plan
- [x] Verify .gitignore properly excludes local development files
- [x] Confirm CLAUDE.md renders correctly
- [x] Ensure pre-commit hooks still function (Prettier, ESLint, TypeScript)
- [x] Validate Serena configuration loads properly

## Impact
This change improves the developer experience by:
- Providing clear documentation for Claude Code usage
- Preventing accidental commits of local configuration files
- Enabling better code analysis with Serena tools
- Establishing consistent development patterns