### PR TITLE
fix(build): Migrate Tailwind CSS from PostCSS to Vite plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",
-    "@tailwindcss/postcss": "^4.1.11",
+    "@tailwindcss/vite": "^4.1.11",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.539.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,9 +10,9 @@ importers:
       "@radix-ui/react-slot":
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.9)(react@19.1.1)
-      "@tailwindcss/postcss":
+      "@tailwindcss/vite":
         specifier: ^4.1.11
-        version: 4.1.11
+        version: 4.1.11(vite@6.3.5(@types/node@24.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -130,13 +130,6 @@ packages:
     peerDependenciesMeta:
       rollup:
         optional: true
-
-  "@alloc/quick-lru@5.2.0":
-    resolution:
-      {
-        integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==,
-      }
-    engines: { node: ">=10" }
 
   "@ampproject/remapping@2.3.0":
     resolution:
@@ -1181,11 +1174,13 @@ packages:
       }
     engines: { node: ">= 10" }
 
-  "@tailwindcss/postcss@4.1.11":
+  "@tailwindcss/vite@4.1.11":
     resolution:
       {
-        integrity: sha512-q/EAIIpF6WpLhKEuQSEVMZNMIY8KhWoAemZ9eylNAih9jxMGAYPPWBn3I9QL/2jZ+e7OEz/tZkX5HwbBR4HohA==,
+        integrity: sha512-RHYhrR3hku0MJFRV+fN2gNbDNEh3dwKvY8XJvTxCSXeMOsCRSr+uKvDWQcbizrHgjML6ZmTE5OwMrl5wKcujCw==,
       }
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7
 
   "@types/babel__core@7.20.5":
     resolution:
@@ -5958,8 +5953,6 @@ snapshots:
     optionalDependencies:
       rollup: 4.46.2
 
-  "@alloc/quick-lru@5.2.0": {}
-
   "@ampproject/remapping@2.3.0":
     dependencies:
       "@jridgewell/gen-mapping": 0.3.12
@@ -6533,13 +6526,12 @@ snapshots:
       "@tailwindcss/oxide-win32-arm64-msvc": 4.1.11
       "@tailwindcss/oxide-win32-x64-msvc": 4.1.11
 
-  "@tailwindcss/postcss@4.1.11":
+  "@tailwindcss/vite@4.1.11(vite@6.3.5(@types/node@24.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))":
     dependencies:
-      "@alloc/quick-lru": 5.2.0
       "@tailwindcss/node": 4.1.11
       "@tailwindcss/oxide": 4.1.11
-      postcss: 8.5.6
       tailwindcss: 4.1.11
+      vite: 6.3.5(@types/node@24.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
 
   "@types/babel__core@7.20.5":
     dependencies:

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,0 @@
-export default {
-  plugins: {
-    "@tailwindcss/postcss": {},
-  },
-};

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -1,6 +1,10 @@
+import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "wxt";
 
 // See https://wxt.dev/api/config.html
 export default defineConfig({
   modules: ["@wxt-dev/module-react"],
+  vite: () => ({
+    plugins: [tailwindcss()],
+  }),
 });


### PR DESCRIPTION
## Summary
Migrates Tailwind CSS configuration from PostCSS to Vite plugin for better WXT integration and improved build performance.

## Context
This PR improves the Tailwind CSS setup introduced in #3 by migrating from PostCSS to Vite plugin, which is the recommended approach for Vite-based projects like WXT.

## Changes
- Replace `@tailwindcss/postcss` with `@tailwindcss/vite` package
- Remove `postcss.config.mjs` (no longer needed with Vite plugin)
- Configure Tailwind as a Vite plugin in `wxt.config.ts`
- Update import order for better code organization

## Why This Change?
- **Better HMR performance**: Vite plugin provides faster hot module replacement
- **Simplified configuration**: Eliminates the need for separate PostCSS config file
- **WXT compatibility**: Aligns with WXT's native Vite-based architecture
- **Reduced complexity**: One less configuration file to maintain

## Testing
- [x] Development build works (`pnpm dev`)
- [x] Production build succeeds (`pnpm build`)
- [x] Tailwind styles are properly applied
- [x] HMR works correctly with style changes
- [x] All lint checks pass

## Related Issues
Relates to #3 - Initial Tailwind CSS and shadcn/ui setup

## Migration Impact
This is a non-breaking change that improves the build pipeline without affecting functionality. The UI remains visually identical, but the build process is now more efficient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Tailwind CSS integration to use the Vite plugin.
  * Removed the PostCSS configuration file.
  * Updated dependencies to replace the PostCSS plugin with the Vite plugin for Tailwind CSS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->