### PR TITLE
fix(ci): add manual trigger and permissions for release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   lint:
@@ -152,7 +153,13 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs: [lint, build, e2e-test]
-    if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
+
+    # Required for creating tag and release
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Added manual workflow trigger capability via `workflow_dispatch`
- Fixed permission error when creating tags and releases
- Updated release job conditions to support both automatic and manual execution

## Problem
The release job was failing with the following error:
```
Error: Error Command failed: git push origin 25.8.10
remote: Permission to White-Rabbit-Lab/browser-extension.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/White-Rabbit-Lab/browser-extension/': The requested URL returned error: 403
```

## Root Cause
The `daily-version-action` was attempting to create and push a new tag, but `github-actions[bot]` lacked the necessary write permissions.

## Solution
1. **Added `workflow_dispatch` event**: Enables manual triggering of the workflow from GitHub Actions UI
2. **Added `permissions: contents: write`**: Grants the workflow permission to create tags and releases
3. **Updated release job condition**: Now runs on either manual trigger or push to main branch

## How to Use Manual Trigger
1. Navigate to the Actions tab in the GitHub repository
2. Select "CI" workflow from the left sidebar
3. Click "Run workflow" button
4. Select the branch and run

## Testing
- The workflow can now be manually triggered without waiting for a push to main
- The permission issue for creating tags and releases is resolved