### PR TITLE
fix(ci): update zip filename to match project name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
         run: pnpm run zip
 
       - name: Rename zip file
-        run: mv .output/nocode-web-assistant-${{ steps.daily_version.outputs.version }}-chrome.zip nocode-web-assistant-chrome-${{ steps.daily_version.outputs.version }}.zip
+        run: mv .output/wxt-react-starter-${{ steps.daily_version.outputs.version }}-chrome.zip wxt-react-starter-chrome-${{ steps.daily_version.outputs.version }}.zip
 
       - name: Check if release exists
         id: check_release
@@ -223,6 +223,6 @@ jobs:
           prerelease: false
           generate_release_notes: true
           files: |
-            nocode-web-assistant-chrome-${{ steps.daily_version.outputs.version }}.zip
+            wxt-react-starter-chrome-${{ steps.daily_version.outputs.version }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Updated zip filename in release workflow from `nocode-web-assistant` to `wxt-react-starter`
- Ensures the generated zip file matches the actual project name

## Changes

- Modified `.github/workflows/ci.yml` to use correct project name in:
  - Zip file renaming step
  - Release artifact upload step

## Test Plan

- [ ] CI workflow runs successfully
- [ ] Release artifacts are generated with correct filename
- [ ] Zip file can be downloaded from GitHub releases